### PR TITLE
Add stock-research-agent package with analysis modules, CLI, AI summary, reports, and tests

### DIFF
--- a/stock-research-agent/.env.example
+++ b/stock-research-agent/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key_here

--- a/stock-research-agent/.gitignore
+++ b/stock-research-agent/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.env
+output/*.md

--- a/stock-research-agent/README.md
+++ b/stock-research-agent/README.md
@@ -1,0 +1,64 @@
+# stock-research-agent
+
+A beginner-friendly modular Python project to analyze a stock ticker and produce a markdown report.
+
+> **Educational disclaimer:** This project is for learning purposes only and is **not financial advice**.
+
+## Features
+
+- Current price and valuation snapshot
+- Latest fundamentals extraction
+- Growth drivers and risks commentary
+- Practical trim/re-entry zones (simple, educational heuristics)
+- Optional OpenAI human-style summary
+- Markdown report output
+
+## Requirements
+
+- Python 3.11+
+
+## Installation
+
+```bash
+cd stock-research-agent
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+```
+
+## OpenAI setup (optional)
+
+```bash
+cp .env.example .env
+# then add your key in .env
+```
+
+## Usage
+
+```bash
+python -m stock_agent AVGO
+python -m stock_agent AVGO --ai-summary --save
+```
+
+When using `--save`, reports are written to `output/`.
+
+## Testing
+
+```bash
+pytest -q
+```
+
+## Publish to GitHub
+
+If you want this project as a GitHub repository:
+
+```bash
+git init
+git add .
+git commit -m "Initial commit: stock-research-agent"
+git branch -M main
+git remote add origin https://github.com/<your-username>/stock-research-agent.git
+git push -u origin main
+```
+
+You can also create the remote first using the GitHub web UI, then run the same commands.

--- a/stock-research-agent/requirements.txt
+++ b/stock-research-agent/requirements.txt
@@ -1,0 +1,4 @@
+yfinance>=0.2.54
+python-dotenv>=1.0.1
+openai>=1.30.0
+pytest>=8.0.0

--- a/stock-research-agent/stock_agent/__init__.py
+++ b/stock-research-agent/stock_agent/__init__.py
@@ -1,0 +1,3 @@
+"""Stock research agent package."""
+
+__all__: list[str] = []

--- a/stock-research-agent/stock_agent/__main__.py
+++ b/stock-research-agent/stock_agent/__main__.py
@@ -1,0 +1,6 @@
+"""Module entrypoint for `python -m stock_agent`."""
+
+from .cli import run
+
+if __name__ == "__main__":
+    run()

--- a/stock-research-agent/stock_agent/ai/__init__.py
+++ b/stock-research-agent/stock_agent/ai/__init__.py
@@ -1,0 +1,1 @@
+"""AI summary generation package."""

--- a/stock-research-agent/stock_agent/ai/prompts.py
+++ b/stock-research-agent/stock_agent/ai/prompts.py
@@ -1,0 +1,15 @@
+"""Prompt builders for AI summary."""
+
+from stock_agent.models import StockAnalysis
+
+
+def build_summary_prompt(analysis: StockAnalysis) -> str:
+    """Build a concise prompt for generating a human-style summary."""
+    return (
+        f"Summarize {analysis.valuation.ticker} in plain English for a beginner investor. "
+        f"Current price: {analysis.valuation.current_price}. "
+        f"Valuation: {analysis.valuation.valuation_label}. "
+        f"Drivers: {analysis.growth_drivers}. Risks: {analysis.growth_risks}. "
+        f"Trim zone: {analysis.zones.trim_zone}. Re-entry zone: {analysis.zones.reentry_zone}. "
+        "Keep it balanced and practical in under 180 words."
+    )

--- a/stock-research-agent/stock_agent/ai/summary.py
+++ b/stock-research-agent/stock_agent/ai/summary.py
@@ -1,0 +1,27 @@
+"""Optional OpenAI-powered summary generator."""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from stock_agent.ai.prompts import build_summary_prompt
+from stock_agent.models import StockAnalysis
+
+
+def generate_ai_summary(analysis: StockAnalysis, model: str = "gpt-4o-mini") -> str:
+    """Generate an AI summary if OPENAI_API_KEY is set."""
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set. Add it to your .env file.")
+
+    client = OpenAI(api_key=api_key)
+    prompt = build_summary_prompt(analysis)
+    response = client.responses.create(
+        model=model,
+        input=prompt,
+    )
+    return response.output_text.strip()

--- a/stock-research-agent/stock_agent/analysis/__init__.py
+++ b/stock-research-agent/stock_agent/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Analysis modules for stock research."""

--- a/stock-research-agent/stock_agent/analysis/fundamentals.py
+++ b/stock-research-agent/stock_agent/analysis/fundamentals.py
@@ -1,0 +1,33 @@
+"""Fundamentals extraction and growth drivers."""
+
+from stock_agent.models import FundamentalsSnapshot
+
+
+def build_fundamentals(info: dict) -> FundamentalsSnapshot:
+    """Extract key fundamentals from info payload."""
+    def v(key: str) -> float | None:
+        raw = info.get(key)
+        return float(raw) if raw is not None else None
+
+    return FundamentalsSnapshot(
+        revenue_growth=v("revenueGrowth"),
+        earnings_growth=v("earningsGrowth"),
+        gross_margins=v("grossMargins"),
+        operating_margins=v("operatingMargins"),
+        debt_to_equity=v("debtToEquity"),
+        return_on_equity=v("returnOnEquity"),
+    )
+
+
+def growth_drivers(f: FundamentalsSnapshot) -> list[str]:
+    """Generate plain-language growth drivers."""
+    drivers: list[str] = []
+    if f.revenue_growth and f.revenue_growth > 0.1:
+        drivers.append("Strong revenue growth trend.")
+    if f.earnings_growth and f.earnings_growth > 0.1:
+        drivers.append("Healthy earnings expansion.")
+    if f.gross_margins and f.gross_margins > 0.4:
+        drivers.append("High gross margins support profitability.")
+    if not drivers:
+        drivers.append("No obvious quantitative growth driver from recent fundamentals.")
+    return drivers

--- a/stock-research-agent/stock_agent/analysis/price_zones.py
+++ b/stock-research-agent/stock_agent/analysis/price_zones.py
@@ -1,0 +1,24 @@
+"""Price zone calculations for trimming and re-entry."""
+
+from stock_agent.models import PriceZones
+
+
+def calculate_price_zones(current_price: float) -> PriceZones:
+    """Calculate practical zones using simple percentage bands.
+
+    This is intentionally simple and educational.
+    """
+    if current_price <= 0:
+        raise ValueError("Current price must be greater than zero.")
+
+    trim_low = current_price * 1.1
+    trim_high = current_price * 1.2
+    reentry_low = current_price * 0.85
+    reentry_high = current_price * 0.95
+
+    return PriceZones(
+        trim_zone=(round(trim_low, 2), round(trim_high, 2)),
+        reentry_zone=(round(reentry_low, 2), round(reentry_high, 2)),
+        support=round(reentry_low, 2),
+        resistance=round(trim_high, 2),
+    )

--- a/stock-research-agent/stock_agent/analysis/risks.py
+++ b/stock-research-agent/stock_agent/analysis/risks.py
@@ -1,0 +1,17 @@
+"""Risk analysis helpers."""
+
+from stock_agent.models import FundamentalsSnapshot
+
+
+def growth_risks(f: FundamentalsSnapshot, pe_ratio: float | None) -> list[str]:
+    """Generate key risk statements."""
+    risks: list[str] = []
+    if pe_ratio is not None and pe_ratio > 35:
+        risks.append("Valuation is elevated and may compress.")
+    if f.debt_to_equity is not None and f.debt_to_equity > 150:
+        risks.append("Leverage is high relative to equity.")
+    if f.operating_margins is not None and f.operating_margins < 0.1:
+        risks.append("Thin operating margins increase downside sensitivity.")
+    if not risks:
+        risks.append("No major red flags in selected metrics, but execution risk remains.")
+    return risks

--- a/stock-research-agent/stock_agent/analysis/valuation.py
+++ b/stock-research-agent/stock_agent/analysis/valuation.py
@@ -1,0 +1,29 @@
+"""Valuation analysis helpers."""
+
+from __future__ import annotations
+
+from stock_agent.models import PriceValuation
+
+
+def classify_valuation(pe_ratio: float | None) -> str:
+    """Classify valuation from PE ratio."""
+    if pe_ratio is None:
+        return "unknown"
+    if pe_ratio < 15:
+        return "possibly undervalued"
+    if pe_ratio <= 30:
+        return "fairly valued"
+    return "possibly overvalued"
+
+
+def build_valuation(ticker: str, info: dict) -> PriceValuation:
+    """Build valuation object from yfinance info."""
+    pe = info.get("trailingPE")
+    return PriceValuation(
+        ticker=ticker.upper(),
+        current_price=float(info.get("currentPrice") or 0.0),
+        pe_ratio=float(pe) if pe is not None else None,
+        forward_pe=float(info.get("forwardPE")) if info.get("forwardPE") is not None else None,
+        market_cap=float(info.get("marketCap")) if info.get("marketCap") is not None else None,
+        valuation_label=classify_valuation(float(pe) if pe is not None else None),
+    )

--- a/stock-research-agent/stock_agent/cli.py
+++ b/stock-research-agent/stock_agent/cli.py
@@ -1,0 +1,54 @@
+"""CLI entrypoint for stock agent."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from stock_agent.ai.summary import generate_ai_summary
+from stock_agent.analysis.fundamentals import build_fundamentals, growth_drivers
+from stock_agent.analysis.price_zones import calculate_price_zones
+from stock_agent.analysis.risks import growth_risks
+from stock_agent.analysis.valuation import build_valuation
+from stock_agent.data.market_data import get_stock_info
+from stock_agent.models import StockAnalysis
+from stock_agent.reports.markdown_report import render_markdown_report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Stock research agent")
+    parser.add_argument("ticker", help="Ticker symbol like AVGO")
+    parser.add_argument("--ai-summary", action="store_true", help="Generate optional AI summary with OpenAI API")
+    parser.add_argument("--save", action="store_true", help="Save markdown report to output folder")
+    return parser
+
+
+def run() -> None:
+    args = build_parser().parse_args()
+    info = get_stock_info(args.ticker)
+
+    valuation = build_valuation(args.ticker, info)
+    fundamentals = build_fundamentals(info)
+    analysis = StockAnalysis(
+        valuation=valuation,
+        fundamentals=fundamentals,
+        growth_drivers=growth_drivers(fundamentals),
+        growth_risks=growth_risks(fundamentals, valuation.pe_ratio),
+        zones=calculate_price_zones(valuation.current_price),
+    )
+
+    if args.ai_summary:
+        try:
+            analysis.ai_summary = generate_ai_summary(analysis)
+        except Exception as exc:
+            analysis.ai_summary = f"AI summary unavailable: {exc}"
+
+    report = render_markdown_report(analysis)
+    print(report)
+
+    if args.save:
+        output_dir = Path("output")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        out_file = output_dir / f"{args.ticker.upper()}_report.md"
+        out_file.write_text(report, encoding="utf-8")
+        print(f"Saved report to {out_file}")

--- a/stock-research-agent/stock_agent/data/__init__.py
+++ b/stock-research-agent/stock_agent/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data access layer."""

--- a/stock-research-agent/stock_agent/data/market_data.py
+++ b/stock-research-agent/stock_agent/data/market_data.py
@@ -1,0 +1,13 @@
+"""Market data fetching utilities built on yfinance."""
+
+from __future__ import annotations
+
+import yfinance as yf
+
+
+def get_stock_info(ticker: str) -> dict:
+    """Return info dictionary for a ticker symbol."""
+    try:
+        return yf.Ticker(ticker).info
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError(f"Failed to fetch data for {ticker}: {exc}") from exc

--- a/stock-research-agent/stock_agent/models.py
+++ b/stock-research-agent/stock_agent/models.py
@@ -1,0 +1,41 @@
+"""Data models for stock analysis results."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PriceValuation:
+    ticker: str
+    current_price: float
+    pe_ratio: float | None
+    forward_pe: float | None
+    market_cap: float | None
+    valuation_label: str
+
+
+@dataclass
+class FundamentalsSnapshot:
+    revenue_growth: float | None
+    earnings_growth: float | None
+    gross_margins: float | None
+    operating_margins: float | None
+    debt_to_equity: float | None
+    return_on_equity: float | None
+
+
+@dataclass
+class PriceZones:
+    trim_zone: tuple[float, float]
+    reentry_zone: tuple[float, float]
+    support: float
+    resistance: float
+
+
+@dataclass
+class StockAnalysis:
+    valuation: PriceValuation
+    fundamentals: FundamentalsSnapshot
+    growth_drivers: list[str]
+    growth_risks: list[str]
+    zones: PriceZones
+    ai_summary: str | None = None

--- a/stock-research-agent/stock_agent/reports/__init__.py
+++ b/stock-research-agent/stock_agent/reports/__init__.py
@@ -1,0 +1,1 @@
+"""Report rendering package."""

--- a/stock-research-agent/stock_agent/reports/markdown_report.py
+++ b/stock-research-agent/stock_agent/reports/markdown_report.py
@@ -1,0 +1,47 @@
+"""Markdown report renderer."""
+
+from stock_agent.models import StockAnalysis
+
+
+def render_markdown_report(analysis: StockAnalysis) -> str:
+    """Render a markdown report for stock analysis."""
+    v = analysis.valuation
+    f = analysis.fundamentals
+    lines = [
+        f"# Stock Research Report: {v.ticker}",
+        "",
+        "> **Educational disclaimer:** This report is for educational purposes only and is **not financial advice**.",
+        "",
+        "## 1) Current price and valuation",
+        f"- Current price: **${v.current_price:.2f}**",
+        f"- Trailing P/E: **{v.pe_ratio}**",
+        f"- Forward P/E: **{v.forward_pe}**",
+        f"- Market cap: **{v.market_cap}**",
+        f"- Valuation view: **{v.valuation_label}**",
+        "",
+        "## 2) Latest fundamentals",
+        f"- Revenue growth: **{f.revenue_growth}**",
+        f"- Earnings growth: **{f.earnings_growth}**",
+        f"- Gross margins: **{f.gross_margins}**",
+        f"- Operating margins: **{f.operating_margins}**",
+        f"- Debt-to-equity: **{f.debt_to_equity}**",
+        f"- Return on equity: **{f.return_on_equity}**",
+        "",
+        "## 3) Growth drivers",
+    ]
+    lines.extend([f"- {item}" for item in analysis.growth_drivers])
+    lines.extend(["", "## 4) Growth risks"])
+    lines.extend([f"- {item}" for item in analysis.growth_risks])
+    lines.extend(
+        [
+            "",
+            "## 5) Practical trim and re-entry zones",
+            f"- Trim zone: **${analysis.zones.trim_zone[0]} - ${analysis.zones.trim_zone[1]}**",
+            f"- Re-entry zone: **${analysis.zones.reentry_zone[0]} - ${analysis.zones.reentry_zone[1]}**",
+            f"- Support: **${analysis.zones.support}**",
+            f"- Resistance: **${analysis.zones.resistance}**",
+        ]
+    )
+    if analysis.ai_summary:
+        lines.extend(["", "## 6) Optional AI summary", analysis.ai_summary])
+    return "\n".join(lines) + "\n"

--- a/stock-research-agent/tests/conftest.py
+++ b/stock-research-agent/tests/conftest.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/stock-research-agent/tests/test_price_zones.py
+++ b/stock-research-agent/tests/test_price_zones.py
@@ -1,0 +1,14 @@
+from stock_agent.analysis.price_zones import calculate_price_zones
+
+
+def test_calculate_price_zones_basic() -> None:
+    zones = calculate_price_zones(100)
+    assert zones.trim_zone == (110.0, 120.0)
+    assert zones.reentry_zone == (85.0, 95.0)
+
+
+def test_calculate_price_zones_invalid() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        calculate_price_zones(0)

--- a/stock-research-agent/tests/test_risks.py
+++ b/stock-research-agent/tests/test_risks.py
@@ -1,0 +1,15 @@
+from stock_agent.analysis.risks import growth_risks
+from stock_agent.models import FundamentalsSnapshot
+
+
+def test_growth_risks_detects_red_flags() -> None:
+    f = FundamentalsSnapshot(
+        revenue_growth=0.2,
+        earnings_growth=0.2,
+        gross_margins=0.5,
+        operating_margins=0.08,
+        debt_to_equity=200,
+        return_on_equity=0.2,
+    )
+    risks = growth_risks(f, 40)
+    assert len(risks) >= 2

--- a/stock-research-agent/tests/test_valuation.py
+++ b/stock-research-agent/tests/test_valuation.py
@@ -1,0 +1,8 @@
+from stock_agent.analysis.valuation import classify_valuation
+
+
+def test_valuation_labels() -> None:
+    assert classify_valuation(10) == "possibly undervalued"
+    assert classify_valuation(20) == "fairly valued"
+    assert classify_valuation(40) == "possibly overvalued"
+    assert classify_valuation(None) == "unknown"


### PR DESCRIPTION
### Motivation
- Provide a beginner-friendly modular Python project to analyze a stock ticker and produce a markdown report with optional AI-generated summary.
- Encapsulate valuation, fundamentals, risk, and simple price-zone heuristics into reusable analysis modules for educational use.
- Include a CLI entrypoint and lightweight data access so users can run `python -m stock_agent <TICKER>` and optionally save reports.

### Description
- Add a new `stock_agent` package with data models in `models.py` and a CLI in `cli.py` that composes analysis and renders a markdown report via `render_markdown_report`.
- Implement analysis modules: `analysis/valuation.py` (PE-based classification and `build_valuation`), `analysis/fundamentals.py` (fundamentals extraction and `growth_drivers`), `analysis/risks.py` (`growth_risks`), and `analysis/price_zones.py` (`calculate_price_zones`).
- Add data fetching via `data/market_data.py` using `yfinance`, optional OpenAI-powered summary in `ai/summary.py` with prompt builder in `ai/prompts.py` (uses `OPENAI_API_KEY` from `.env`), and markdown renderer in `reports/markdown_report.py` with save-to-`output/` support.
- Add project metadata and developer convenience files: `README.md`, `requirements.txt`, `.env.example`, and `.gitignore`.
- Add unit tests for price zones, risks, and valuation under `tests/` and a `conftest.py` to expose the package for tests.

### Testing
- Ran `pytest -q` which executed `tests/test_price_zones.py`, `tests/test_risks.py`, and `tests/test_valuation.py`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f89d19e4832f92b7a6667865ac42)